### PR TITLE
Add profile management, CV handling and application features

### DIFF
--- a/src/main/java/com/bupt/tarecruit/model/Application.java
+++ b/src/main/java/com/bupt/tarecruit/model/Application.java
@@ -9,6 +9,7 @@ public class Application {
     private String jobId;
     private ApplicationStatus status;
     private Instant appliedAt;
+    private Instant reviewedAt;
 
     public static Application create(final String applicantUserId, final String jobId) {
         Application application = new Application();
@@ -30,4 +31,6 @@ public class Application {
     public void setStatus(final ApplicationStatus status) { this.status = status; }
     public Instant getAppliedAt() { return appliedAt; }
     public void setAppliedAt(final Instant appliedAt) { this.appliedAt = appliedAt; }
+    public Instant getReviewedAt() { return reviewedAt; }
+    public void setReviewedAt(final Instant reviewedAt) { this.reviewedAt = reviewedAt; }
 }

--- a/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
+++ b/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
@@ -58,6 +58,14 @@ public class ApplicationService {
         return applicationDao.findByApplicantId(applicantUserId);
     }
 
+    public Optional<Application> findByApplicantAndJob(final String applicantUserId, final String jobId) {
+        DataValidator.validateRequired(applicantUserId, "Applicant user ID");
+        DataValidator.validateRequired(jobId, "Job ID");
+        return applicationDao.findByApplicantId(applicantUserId).stream()
+                .filter(application -> application.getJobId().equals(jobId))
+                .findFirst();
+    }
+
     public Optional<Application> getApplicationDetails(final String applicationId) {
         DataValidator.validateRequired(applicationId, "Application ID");
         return applicationDao.findById(applicationId);
@@ -69,8 +77,7 @@ public class ApplicationService {
     }
 
     private boolean hasExistingApplication(final String applicantUserId, final String jobId) {
-        return applicationDao.findByApplicantId(applicantUserId).stream()
-                .anyMatch(application -> application.getJobId().equals(jobId));
+        return findByApplicantAndJob(applicantUserId, jobId).isPresent();
     }
 
     private void validateJobOpenForApplications(final Job job) {

--- a/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
+++ b/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
@@ -3,9 +3,12 @@ package com.bupt.tarecruit.service;
 import com.bupt.tarecruit.dao.ApplicationDao;
 import com.bupt.tarecruit.dao.impl.ApplicationDaoImpl;
 import com.bupt.tarecruit.model.Application;
+import com.bupt.tarecruit.model.ApplicationStatus;
 import com.bupt.tarecruit.model.Job;
 import com.bupt.tarecruit.util.DataValidator;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,7 +40,7 @@ public class ApplicationService {
         if (!applicantService.hasCompleteProfile(applicantUserId)) {
             throw new IllegalArgumentException("Please complete your profile before applying.");
         }
-        if (cvService.findByUserId(applicantUserId).isEmpty()) {
+        if (!cvService.hasUploadedCv(applicantUserId)) {
             throw new IllegalArgumentException("Please upload your CV before applying.");
         }
         if (hasExistingApplication(applicantUserId, jobId)) {
@@ -71,9 +74,56 @@ public class ApplicationService {
         return applicationDao.findById(applicationId);
     }
 
+    public Application getApplicationDetailsForOrganiser(final String organiserUserId, final String applicationId) {
+        DataValidator.validateRequired(organiserUserId, "Organiser user ID");
+        DataValidator.validateRequired(applicationId, "Application ID");
+        Application application = getApplicationDetails(applicationId)
+                .orElseThrow(() -> new IllegalArgumentException("Application not found."));
+        jobService.getOwnedJobForOrganiser(organiserUserId, application.getJobId());
+        return application;
+    }
+
+    public Application openApplicationForOrganiser(final String organiserUserId, final String applicationId) {
+        Application application = getApplicationDetailsForOrganiser(organiserUserId, applicationId);
+        if (application.getStatus() == ApplicationStatus.PENDING && application.getReviewedAt() == null) {
+            application.setStatus(ApplicationStatus.REVIEWING);
+            application.setReviewedAt(Instant.now());
+            applicationDao.save(application);
+        }
+        return application;
+    }
+
     public List<Application> getApplicationsByJob(final String jobId) {
         DataValidator.validateRequired(jobId, "Job ID");
         return applicationDao.findByJobId(jobId);
+    }
+
+    public List<Application> getApplicationsForOrganiserJob(final String organiserUserId, final String jobId) {
+        DataValidator.validateRequired(organiserUserId, "Organiser user ID");
+        DataValidator.validateRequired(jobId, "Job ID");
+        jobService.getOwnedJobForOrganiser(organiserUserId, jobId);
+        return applicationDao.findByJobId(jobId).stream()
+                .sorted(Comparator.comparing(
+                        Application::getAppliedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+                .toList();
+    }
+
+    public Application updateStatusForOrganiser(final String organiserUserId, final String applicationId,
+                                                final ApplicationStatus status) {
+        DataValidator.validateRequired(organiserUserId, "Organiser user ID");
+        DataValidator.validateRequired(applicationId, "Application ID");
+        if (status == null) {
+            throw new IllegalArgumentException("Application status is required.");
+        }
+
+        Application application = getApplicationDetailsForOrganiser(organiserUserId, applicationId);
+        application.setStatus(status);
+        if (application.getReviewedAt() == null) {
+            application.setReviewedAt(Instant.now());
+        }
+        applicationDao.save(application);
+        return application;
     }
 
     private boolean hasExistingApplication(final String applicantUserId, final String jobId) {

--- a/src/main/java/com/bupt/tarecruit/service/CvService.java
+++ b/src/main/java/com/bupt/tarecruit/service/CvService.java
@@ -73,12 +73,17 @@ public class CvService {
         return cvDao.findByUserId(userId);
     }
 
+    public Optional<CV> findAvailableCvByUserId(final String userId) {
+        return findByUserId(userId)
+                .filter(cv -> Files.exists(cvRootDirectory.resolve(userId).resolve(cv.getFileName())));
+    }
+
     public boolean hasUploadedCv(final String userId) {
-        return findByUserId(userId).isPresent();
+        return findAvailableCvByUserId(userId).isPresent();
     }
 
     public Optional<String> currentCvFileName(final String userId) {
-        return findByUserId(userId).map(CV::getFileName);
+        return findAvailableCvByUserId(userId).map(CV::getFileName);
     }
 
     public Path saveFile(final String userId, final String fileName, final InputStream inputStream) {

--- a/src/main/java/com/bupt/tarecruit/servlet/ApplicantProfileServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/ApplicantProfileServlet.java
@@ -18,6 +18,8 @@ public class ApplicantProfileServlet extends BaseServlet {
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response)
             throws ServletException, IOException {
         User user = SessionUtil.currentUser(request);
+        request.setAttribute("skillsText", "");
+        request.setAttribute("preferredWorkingDaysText", "");
         applicantService.findByUserId(user.getId()).ifPresent(profile -> {
             request.setAttribute("profile", profile);
             request.setAttribute("skillsText", applicantService.formatEntries(profile.getSkills()));

--- a/src/main/java/com/bupt/tarecruit/servlet/ApplicantProfileServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/ApplicantProfileServlet.java
@@ -3,6 +3,7 @@ package com.bupt.tarecruit.servlet;
 import com.bupt.tarecruit.model.Applicant;
 import com.bupt.tarecruit.model.User;
 import com.bupt.tarecruit.service.ApplicantService;
+import com.bupt.tarecruit.service.CvService;
 import com.bupt.tarecruit.util.SessionUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -13,6 +14,7 @@ import java.io.IOException;
 @WebServlet("/applicant/profile")
 public class ApplicantProfileServlet extends BaseServlet {
     private final ApplicantService applicantService = new ApplicantService();
+    private final CvService cvService = new CvService();
 
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response)
@@ -20,6 +22,8 @@ public class ApplicantProfileServlet extends BaseServlet {
         User user = SessionUtil.currentUser(request);
         request.setAttribute("skillsText", "");
         request.setAttribute("preferredWorkingDaysText", "");
+        request.setAttribute("hasUploadedCv", cvService.hasUploadedCv(user.getId()));
+        request.setAttribute("currentCvFileName", cvService.currentCvFileName(user.getId()).orElse(""));
         applicantService.findByUserId(user.getId()).ifPresent(profile -> {
             request.setAttribute("profile", profile);
             request.setAttribute("skillsText", applicantService.formatEntries(profile.getSkills()));

--- a/src/main/java/com/bupt/tarecruit/servlet/ApplicationDetailServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/ApplicationDetailServlet.java
@@ -36,6 +36,7 @@ public class ApplicationDetailServlet extends BaseServlet {
 
         request.setAttribute("application", application);
         request.setAttribute("job", jobService.findById(application.getJobId()).orElse(null));
+        setApplicationStatusView(request);
         forward(request, response, "applicant/application_detail.jsp");
     }
 }

--- a/src/main/java/com/bupt/tarecruit/servlet/BaseServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/BaseServlet.java
@@ -1,5 +1,6 @@
 package com.bupt.tarecruit.servlet;
 
+import com.bupt.tarecruit.util.ApplicationStatusView;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,5 +24,10 @@ public abstract class BaseServlet extends HttpServlet {
 
     protected void setError(final HttpServletRequest request, final String message) {
         request.setAttribute("error", message);
+    }
+
+    protected void setApplicationStatusView(final HttpServletRequest request) {
+        request.setAttribute("applicationStatusBadgeClasses", ApplicationStatusView.badgeClassByStatusName());
+        request.setAttribute("applicationStatusSummaries", ApplicationStatusView.summaryByStatusName());
     }
 }

--- a/src/main/java/com/bupt/tarecruit/servlet/CreateJobServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/CreateJobServlet.java
@@ -18,13 +18,21 @@ public class CreateJobServlet extends BaseServlet {
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response)
             throws ServletException, IOException {
         request.setAttribute("today", LocalDate.now());
-        forward(request, response, "organiser/create_job.jsp");
+        request.setAttribute("formAction", request.getContextPath() + "/organiser/jobs/create");
+        request.setAttribute("formHeading", "Create job posting");
+        request.setAttribute("submitLabel", "Publish job");
+        forward(request, response, "organiser/job_form.jsp");
     }
 
     @Override
     protected void doPost(final HttpServletRequest request, final HttpServletResponse response)
             throws ServletException, IOException {
         User user = SessionUtil.currentUser(request);
+        prepareForm(request);
+        request.setAttribute("today", LocalDate.now());
+        request.setAttribute("formAction", request.getContextPath() + "/organiser/jobs/create");
+        request.setAttribute("formHeading", "Create job posting");
+        request.setAttribute("submitLabel", "Publish job");
         try {
             String hoursValue = request.getParameter("hoursPerWeek");
             String deadlineValue = request.getParameter("deadline");
@@ -40,16 +48,22 @@ public class CreateJobServlet extends BaseServlet {
             redirect(request, response, "/organiser/jobs");
         } catch (NumberFormatException exception) {
             setError(request, "Hours per week must be a valid number.");
-            request.setAttribute("today", LocalDate.now());
-            forward(request, response, "organiser/create_job.jsp");
+            forward(request, response, "organiser/job_form.jsp");
         } catch (java.time.format.DateTimeParseException exception) {
             setError(request, "Please choose a valid deadline.");
-            request.setAttribute("today", LocalDate.now());
-            forward(request, response, "organiser/create_job.jsp");
+            forward(request, response, "organiser/job_form.jsp");
         } catch (IllegalArgumentException exception) {
             setError(request, exception.getMessage());
-            request.setAttribute("today", LocalDate.now());
-            forward(request, response, "organiser/create_job.jsp");
+            forward(request, response, "organiser/job_form.jsp");
         }
+    }
+
+    private void prepareForm(final HttpServletRequest request) {
+        request.setAttribute("formTitle", request.getParameter("title"));
+        request.setAttribute("formDepartment", request.getParameter("department"));
+        request.setAttribute("formDescription", request.getParameter("description"));
+        request.setAttribute("formRequirements", request.getParameter("requirements"));
+        request.setAttribute("formHoursPerWeek", request.getParameter("hoursPerWeek"));
+        request.setAttribute("formDeadline", request.getParameter("deadline"));
     }
 }

--- a/src/main/java/com/bupt/tarecruit/servlet/CvUploadServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/CvUploadServlet.java
@@ -32,11 +32,13 @@ public class CvUploadServlet extends BaseServlet {
         User user = SessionUtil.currentUser(request);
         Part part = request.getPart("cv");
         try {
+            boolean replacingExistingCv = cvService.hasUploadedCv(user.getId());
             if (part == null || part.getSubmittedFileName() == null || part.getSubmittedFileName().isBlank()) {
                 throw new IllegalArgumentException("Please choose a CV file.");
             }
             cvService.uploadCV(user.getId(), part.getSubmittedFileName(), part.getInputStream());
-            request.getSession().setAttribute("flash", "CV uploaded successfully.");
+            request.getSession().setAttribute("flash",
+                    replacingExistingCv ? "CV replaced successfully." : "CV uploaded successfully.");
         } catch (IllegalArgumentException | IllegalStateException exception) {
             request.getSession().setAttribute("flash", exception.getMessage());
         }

--- a/src/main/java/com/bupt/tarecruit/servlet/CvUploadServlet.java
+++ b/src/main/java/com/bupt/tarecruit/servlet/CvUploadServlet.java
@@ -23,6 +23,8 @@ public class CvUploadServlet extends BaseServlet {
             throws ServletException, IOException {
         User user = SessionUtil.currentUser(request);
         request.setAttribute("profile", applicantService.findByUserId(user.getId()).orElse(null));
+        request.setAttribute("hasUploadedCv", cvService.hasUploadedCv(user.getId()));
+        request.setAttribute("currentCvFileName", cvService.currentCvFileName(user.getId()).orElse(""));
         forward(request, response, "applicant/upload_cv.jsp");
     }
 

--- a/src/main/java/com/bupt/tarecruit/util/ApplicationStatusView.java
+++ b/src/main/java/com/bupt/tarecruit/util/ApplicationStatusView.java
@@ -1,0 +1,46 @@
+package com.bupt.tarecruit.util;
+
+import com.bupt.tarecruit.model.ApplicationStatus;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class ApplicationStatusView {
+    private ApplicationStatusView() {
+    }
+
+    public static Map<String, String> badgeClassByStatusName() {
+        return toNameKeyedMap(new EnumMap<>(Map.of(
+                ApplicationStatus.PENDING, "app-status-pending",
+                ApplicationStatus.REVIEWING, "app-status-reviewing",
+                ApplicationStatus.ACCEPTED, "app-status-accepted",
+                ApplicationStatus.REJECTED, "app-status-rejected")));
+    }
+
+    public static Map<String, String> summaryByStatusName() {
+        return toNameKeyedMap(new EnumMap<>(Map.of(
+                ApplicationStatus.PENDING, "Waiting for organiser review.",
+                ApplicationStatus.REVIEWING, "An organiser is reviewing your application.",
+                ApplicationStatus.ACCEPTED, "Your application has been accepted.",
+                ApplicationStatus.REJECTED, "Your application has been rejected.")));
+    }
+
+    public static String badgeClassFor(final ApplicationStatus status) {
+        if (status == null) {
+            return "app-status-pending";
+        }
+        return badgeClassByStatusName().getOrDefault(status.name(), "app-status-pending");
+    }
+
+    public static String summaryFor(final ApplicationStatus status) {
+        if (status == null) {
+            return "Application status is currently unavailable.";
+        }
+        return summaryByStatusName().getOrDefault(status.name(), "Application status is currently unavailable.");
+    }
+
+    private static Map<String, String> toNameKeyedMap(final EnumMap<ApplicationStatus, String> values) {
+        return values.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(entry -> entry.getKey().name(), Map.Entry::getValue));
+    }
+}

--- a/src/test/java/com/bupt/tarecruit/service/ApplicantServiceTest.java
+++ b/src/test/java/com/bupt/tarecruit/service/ApplicantServiceTest.java
@@ -1,123 +1,367 @@
 package com.bupt.tarecruit.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.bupt.tarecruit.dao.impl.ApplicantDaoImpl;
+import com.bupt.tarecruit.dao.impl.ApplicationDaoImpl;
+import com.bupt.tarecruit.dao.impl.CvDaoImpl;
 import com.bupt.tarecruit.model.Applicant;
+import com.bupt.tarecruit.model.Application;
+import com.bupt.tarecruit.model.ApplicationStatus;
+import com.bupt.tarecruit.model.Job;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class ApplicantServiceTest {
+class ApplicationServiceTest {
     @Test
-    void createProfileAndAttachCv() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
+    void submitApplicationCreatesPendingRecordWithTimestamp() throws Exception {
+        TestContext context = createContext();
+        Job job = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
 
-        Applicant profile = service.createProfile(
-                "user-1", "Alice Chen", "+86 13800000000", "20260001", "Computer Science", "Tutor");
-        service.attachCv("user-1", "cv.pdf");
+        Application application = context.applicationService.submitApplication("user-1", job.getId());
 
-        assertEquals("Alice Chen", profile.getFullName());
-        assertEquals("cv.pdf", service.findByUserId("user-1").orElseThrow().getCvFileName());
+        assertEquals("user-1", application.getApplicantUserId());
+        assertEquals(job.getId(), application.getJobId());
+        assertEquals(ApplicationStatus.PENDING, application.getStatus());
+        assertNotNull(application.getAppliedAt());
+        assertTrue(context.applicationService.getApplicationDetails(application.getId()).isPresent());
     }
 
     @Test
-    void invalidPhoneIsRejected() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
+    void duplicateApplicationIsRejected() throws Exception {
+        TestContext context = createContext();
+        Job job = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
 
-        assertThrows(IllegalArgumentException.class,
-                () -> service.createProfile("user-1", "Alice", "abc", "20260001", "CS", ""));
+        context.applicationService.submitApplication("user-1", job.getId());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", job.getId()));
+        assertEquals("You have already applied for this job.", exception.getMessage());
     }
 
     @Test
-    void createProfilePersistsSkillsAndPreferredWorkingDays() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
+    void missingProfileIsRejected() throws Exception {
+        TestContext context = createContext();
+        Job job = createOpenJob(context.jobService, "organiser-1");
 
-        service.createProfile(
-                "user-1",
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", job.getId()));
+        assertEquals("Please complete your profile before applying.", exception.getMessage());
+    }
+
+    @Test
+    void incompleteProfileIsRejected() throws Exception {
+        TestContext context = createContext();
+        Job job = createOpenJob(context.jobService, "organiser-1");
+
+        Applicant incompleteProfile = new Applicant();
+        incompleteProfile.setUserId("user-1");
+        incompleteProfile.setFullName("Alice");
+        incompleteProfile.setProgramme("Computer Science");
+        new ApplicantDaoImpl(context.applicantsFile).save(incompleteProfile);
+        saveCv(context, "user-1", "cv.pdf");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", job.getId()));
+        assertEquals("Please complete your profile before applying.", exception.getMessage());
+    }
+
+    @Test
+    void missingCvIsRejected() throws Exception {
+        TestContext context = createContext();
+        Job job = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", job.getId()));
+        assertEquals("Please upload your CV before applying.", exception.getMessage());
+    }
+
+    @Test
+    void missingJobIsRejected() throws Exception {
+        TestContext context = createContext();
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", "missing-job"));
+        assertEquals("The selected job does not exist.", exception.getMessage());
+    }
+
+    @Test
+    void closedOrExpiredJobIsRejected() throws Exception {
+        TestContext context = createContext();
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Job closedJob = Job.create("organiser-1");
+        closedJob.setTitle("Closed Job");
+        closedJob.setDepartment("CS");
+        closedJob.setDescription("Closed");
+        closedJob.setRequirements(List.of("Java"));
+        closedJob.setHoursPerWeek(8);
+        closedJob.setDeadline(LocalDate.now().plusDays(3));
+        closedJob.setStatus("CLOSED");
+        context.jobService.saveJob(closedJob);
+
+        IllegalArgumentException closedException = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", closedJob.getId()));
+        assertEquals("This job is not open for applications.", closedException.getMessage());
+
+        Job expiredJob = Job.create("organiser-1");
+        expiredJob.setTitle("Expired Job");
+        expiredJob.setDepartment("CS");
+        expiredJob.setDescription("Expired");
+        expiredJob.setRequirements(List.of("Java"));
+        expiredJob.setHoursPerWeek(8);
+        expiredJob.setDeadline(LocalDate.now().minusDays(1));
+        context.jobService.saveJob(expiredJob);
+
+        IllegalArgumentException expiredException = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.submitApplication("user-1", expiredJob.getId()));
+        assertEquals("This job is no longer accepting applications.", expiredException.getMessage());
+    }
+
+    @Test
+    void getApplicationsByApplicantAndJobReturnsMatchingRecords() throws Exception {
+        TestContext context = createContext();
+        Job jobOne = createOpenJob(context.jobService, "organiser-1");
+        Job jobTwo = createOpenJob(context.jobService, "organiser-2");
+        createCompleteProfile(context.applicantService, "user-1");
+        createCompleteProfile(context.applicantService, "user-2");
+        saveCv(context, "user-1", "cv.pdf");
+        saveCv(context, "user-2", "cv.pdf");
+
+        Application applicationOne = context.applicationService.submitApplication("user-1", jobOne.getId());
+        Application applicationTwo = context.applicationService.submitApplication("user-1", jobTwo.getId());
+        context.applicationService.submitApplication("user-2", jobTwo.getId());
+
+        assertEquals(2, context.applicationService.getApplicationsByApplicant("user-1").size());
+        assertEquals(2, context.applicationService.getApplicationsByJob(jobTwo.getId()).size());
+        assertEquals(applicationOne.getId(),
+                context.applicationService.getApplicationDetails(applicationOne.getId()).orElseThrow().getId());
+        assertTrue(context.applicationService.getApplicationsByApplicant("user-1").stream()
+                .anyMatch(application -> application.getId().equals(applicationTwo.getId())));
+    }
+
+    @Test
+    void organiserCanViewApplicationsForOwnedJob() throws Exception {
+        TestContext context = createContext();
+        Job ownedJob = createOpenJob(context.jobService, "organiser-1");
+        Job otherJob = createOpenJob(context.jobService, "organiser-2");
+        createCompleteProfile(context.applicantService, "user-1");
+        createCompleteProfile(context.applicantService, "user-2");
+        saveCv(context, "user-1", "cv.pdf");
+        saveCv(context, "user-2", "cv.pdf");
+
+        Application first = context.applicationService.submitApplication("user-1", ownedJob.getId());
+        Application second = context.applicationService.submitApplication("user-2", ownedJob.getId());
+        context.applicationService.submitApplication("user-2", otherJob.getId());
+
+        List<Application> applications = context.applicationService
+                .getApplicationsForOrganiserJob("organiser-1", ownedJob.getId());
+
+        assertEquals(2, applications.size());
+        assertEquals(second.getId(), applications.get(0).getId());
+        assertTrue(applications.stream().anyMatch(application -> application.getId().equals(first.getId())));
+        assertTrue(applications.stream().anyMatch(application -> application.getId().equals(second.getId())));
+    }
+
+    @Test
+    void organiserCannotViewApplicationsForUnownedJob() throws Exception {
+        TestContext context = createContext();
+        Job ownedByAnotherOrganiser = createOpenJob(context.jobService, "organiser-2");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.getApplicationsForOrganiserJob("organiser-1", ownedByAnotherOrganiser.getId()));
+        assertEquals("You are not allowed to access this job.", exception.getMessage());
+    }
+
+    @Test
+    void organiserCanViewOwnedApplicationDetails() throws Exception {
+        TestContext context = createContext();
+        Job ownedJob = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedJob.getId());
+
+        Application resolved = context.applicationService
+                .getApplicationDetailsForOrganiser("organiser-1", application.getId());
+
+        assertEquals(application.getId(), resolved.getId());
+        assertEquals("user-1", resolved.getApplicantUserId());
+    }
+
+    @Test
+    void organiserCannotViewUnownedApplicationDetails() throws Exception {
+        TestContext context = createContext();
+        Job ownedByAnotherOrganiser = createOpenJob(context.jobService, "organiser-2");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedByAnotherOrganiser.getId());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.getApplicationDetailsForOrganiser("organiser-1", application.getId()));
+        assertEquals("You are not allowed to access this job.", exception.getMessage());
+    }
+
+    @Test
+    void openingPendingApplicationMarksItAsReviewingOnce() throws Exception {
+        TestContext context = createContext();
+        Job ownedJob = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedJob.getId());
+
+        Application reviewed = context.applicationService.openApplicationForOrganiser("organiser-1", application.getId());
+
+        assertEquals(ApplicationStatus.REVIEWING, reviewed.getStatus());
+        assertNotNull(reviewed.getReviewedAt());
+
+        Application openedAgain = context.applicationService.openApplicationForOrganiser("organiser-1", application.getId());
+        assertEquals(ApplicationStatus.REVIEWING, openedAgain.getStatus());
+        assertEquals(reviewed.getReviewedAt(), openedAgain.getReviewedAt());
+    }
+
+    @Test
+    void organiserCanUpdateApplicationStatus() throws Exception {
+        TestContext context = createContext();
+        Job ownedJob = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedJob.getId());
+
+        Application accepted = context.applicationService
+                .updateStatusForOrganiser("organiser-1", application.getId(), ApplicationStatus.ACCEPTED);
+
+        assertEquals(ApplicationStatus.ACCEPTED, accepted.getStatus());
+        assertNotNull(accepted.getReviewedAt());
+        assertEquals(ApplicationStatus.ACCEPTED,
+                context.applicationService.getApplicationDetails(application.getId()).orElseThrow().getStatus());
+    }
+
+    @Test
+    void manualPendingAfterReviewDoesNotAutoReturnToReviewing() throws Exception {
+        TestContext context = createContext();
+        Job ownedJob = createOpenJob(context.jobService, "organiser-1");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedJob.getId());
+        Application reviewing = context.applicationService.openApplicationForOrganiser("organiser-1", application.getId());
+
+        Application pendingAgain = context.applicationService
+                .updateStatusForOrganiser("organiser-1", application.getId(), ApplicationStatus.PENDING);
+        Application reopened = context.applicationService.openApplicationForOrganiser("organiser-1", application.getId());
+
+        assertNotNull(reviewing.getReviewedAt());
+        assertEquals(ApplicationStatus.PENDING, pendingAgain.getStatus());
+        assertEquals(reviewing.getReviewedAt(), pendingAgain.getReviewedAt());
+        assertEquals(ApplicationStatus.PENDING, reopened.getStatus());
+    }
+
+    @Test
+    void organiserCannotUpdateUnownedApplicationStatus() throws Exception {
+        TestContext context = createContext();
+        Job ownedByAnotherOrganiser = createOpenJob(context.jobService, "organiser-2");
+        createCompleteProfile(context.applicantService, "user-1");
+        saveCv(context, "user-1", "cv.pdf");
+
+        Application application = context.applicationService.submitApplication("user-1", ownedByAnotherOrganiser.getId());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> context.applicationService.updateStatusForOrganiser(
+                        "organiser-1",
+                        application.getId(),
+                        ApplicationStatus.REJECTED));
+        assertEquals("You are not allowed to access this job.", exception.getMessage());
+    }
+
+    private TestContext createContext() throws Exception {
+        Path applicantsFile = Files.createTempFile("applicants", ".json");
+        Path jobsFile = Files.createTempFile("jobs", ".json");
+        Path cvsFile = Files.createTempFile("cvs", ".json");
+        Path applicationsFile = Files.createTempFile("applications", ".json");
+
+        ApplicantService applicantService = new ApplicantService(applicantsFile);
+        JobService jobService = new JobService(jobsFile);
+        CvService cvService = new CvService(applicantService, new CvDaoImpl(cvsFile));
+        ApplicationService applicationService = new ApplicationService(
+                applicantService,
+                jobService,
+                cvService,
+                new ApplicationDaoImpl(applicationsFile));
+
+        return new TestContext(applicantService, jobService, cvService, applicationService, applicantsFile, cvsFile);
+    }
+
+    private Job createOpenJob(final JobService jobService, final String organiserUserId) {
+        return jobService.createJob(
+                organiserUserId,
+                "Software Engineering TA",
+                "Computer Science",
+                "Support labs and students.",
+                "Java\nCommunication",
+                8,
+                LocalDate.now().plusDays(7));
+    }
+
+    private void createCompleteProfile(final ApplicantService applicantService, final String userId) {
+        applicantService.createProfile(
+                userId,
                 "Alice Chen",
                 "+86 13800000000",
                 "20260001",
                 "Computer Science",
-                "Tutor",
-                List.of("Java", "Java", " Communication "),
-                List.of("Monday", "", "Wednesday"));
-
-        Applicant profile = service.findByUserId("user-1").orElseThrow();
-        assertEquals(List.of("Java", "Communication"), profile.getSkills());
-        assertEquals(List.of("Monday", "Wednesday"), profile.getPreferredWorkingDays());
+                "Ready to support labs.");
     }
 
-    @Test
-    void createProfileParsesTextBasedSkillsAndAvailability() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
-
-        service.createProfile(
-                "user-1",
-                "Alice Chen",
-                "+86 13800000000",
-                "20260001",
-                "Computer Science",
-                "Tutor",
-                "Java, Communication\nJava",
-                "Monday\nWednesday, Friday");
-
-        Applicant profile = service.findByUserId("user-1").orElseThrow();
-        assertEquals(List.of("Java", "Communication"), profile.getSkills());
-        assertEquals(List.of("Monday", "Wednesday", "Friday"), profile.getPreferredWorkingDays());
+    private void saveCv(final TestContext context, final String userId, final String fileName) {
+        context.cvService.uploadCV(userId, fileName, new ByteArrayInputStream("cv-data".getBytes()));
     }
 
-    @Test
-    void oldCreateProfileMethodRemainsCompatible() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
+    private static final class TestContext {
+        private final ApplicantService applicantService;
+        private final JobService jobService;
+        private final CvService cvService;
+        private final ApplicationService applicationService;
+        private final Path applicantsFile;
+        private final Path cvsFile;
 
-        Applicant profile = service.createProfile(
-                "user-1", "Alice Chen", "+86 13800000000", "20260001", "Computer Science", "Tutor");
-
-        assertEquals(List.of(), profile.getSkills());
-        assertEquals(List.of(), profile.getPreferredWorkingDays());
-    }
-
-    @Test
-    void updatingProfileReplacesSkillsAndAvailability() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
-
-        service.createProfile(
-                "user-1",
-                "Alice Chen",
-                "+86 13800000000",
-                "20260001",
-                "Computer Science",
-                "Tutor",
-                List.of("Java"),
-                List.of("Monday"));
-
-        service.createProfile(
-                "user-1",
-                "Alice Chen",
-                "+86 13800000000",
-                "20260001",
-                "Computer Science",
-                "Tutor",
-                "Testing, Communication",
-                "Tuesday, Thursday");
-
-        Applicant profile = service.findByUserId("user-1").orElseThrow();
-        assertEquals(List.of("Testing", "Communication"), profile.getSkills());
-        assertEquals(List.of("Tuesday", "Thursday"), profile.getPreferredWorkingDays());
-    }
-
-    @Test
-    void formatEntriesProducesStableDisplayText() throws Exception {
-        Path file = Files.createTempFile("applicants", ".json");
-        ApplicantService service = new ApplicantService(file);
-
-        assertEquals("Java, Communication", service.formatEntries(List.of("Java", "Communication")));
+        private TestContext(final ApplicantService applicantService, final JobService jobService,
+                            final CvService cvService, final ApplicationService applicationService,
+                            final Path applicantsFile, final Path cvsFile) {
+            this.applicantService = applicantService;
+            this.jobService = jobService;
+            this.cvService = cvService;
+            this.applicationService = applicationService;
+            this.applicantsFile = applicantsFile;
+            this.cvsFile = cvsFile;
+        }
     }
 }

--- a/src/test/java/com/bupt/tarecruit/service/CvServiceTest.java
+++ b/src/test/java/com/bupt/tarecruit/service/CvServiceTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.bupt.tarecruit.dao.impl.CvDaoImpl;
+import com.bupt.tarecruit.model.CV;
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class CvServiceTest {
@@ -77,5 +79,26 @@ class CvServiceTest {
 
         assertTrue(cvService.hasUploadedCv("user-1"));
         assertEquals("cv.pdf", cvService.currentCvFileName("user-1").orElseThrow());
+    }
+
+    @Test
+    void staleMetadataWithoutDiskFileIsNotShownAsUploaded() throws Exception {
+        Path applicantsFile = Files.createTempFile("applicants", ".json");
+        Path cvsFile = Files.createTempFile("cvs", ".json");
+        Path cvRootDirectory = Files.createTempDirectory("cv-root");
+        ApplicantService applicantService = new ApplicantService(applicantsFile);
+        applicantService.createProfile("user-1", "Alice", "+1 202 555 0100", "20260001", "CS", "");
+        CvService cvService = new CvService(applicantService, new CvDaoImpl(cvsFile), cvRootDirectory);
+
+        CV cv = new CV();
+        cv.setUserId("user-1");
+        cv.setFileName("cv.pdf");
+        cv.setFileType("pdf");
+        cv.setUploadedAt(Instant.now());
+        new CvDaoImpl(cvsFile).save(cv);
+
+        assertFalse(cvService.hasUploadedCv("user-1"));
+        assertTrue(cvService.currentCvFileName("user-1").isEmpty());
+        assertTrue(cvService.findAvailableCvByUserId("user-1").isEmpty());
     }
 }

--- a/src/test/java/com/bupt/tarecruit/util/ApplicationStatusViewTest.java
+++ b/src/test/java/com/bupt/tarecruit/util/ApplicationStatusViewTest.java
@@ -1,0 +1,30 @@
+package com.bupt.tarecruit.util;
+
+import com.bupt.tarecruit.model.ApplicationStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApplicationStatusViewTest {
+    @Test
+    void badgeClassMappingCoversAllStatuses() {
+        assertEquals("app-status-pending", ApplicationStatusView.badgeClassFor(ApplicationStatus.PENDING));
+        assertEquals("app-status-reviewing", ApplicationStatusView.badgeClassFor(ApplicationStatus.REVIEWING));
+        assertEquals("app-status-accepted", ApplicationStatusView.badgeClassFor(ApplicationStatus.ACCEPTED));
+        assertEquals("app-status-rejected", ApplicationStatusView.badgeClassFor(ApplicationStatus.REJECTED));
+    }
+
+    @Test
+    void summaryMappingCoversAllStatuses() {
+        assertEquals("Waiting for organiser review.", ApplicationStatusView.summaryFor(ApplicationStatus.PENDING));
+        assertEquals("An organiser is reviewing your application.", ApplicationStatusView.summaryFor(ApplicationStatus.REVIEWING));
+        assertEquals("Your application has been accepted.", ApplicationStatusView.summaryFor(ApplicationStatus.ACCEPTED));
+        assertEquals("Your application has been rejected.", ApplicationStatusView.summaryFor(ApplicationStatus.REJECTED));
+    }
+
+    @Test
+    void nullStatusFallsBackToSafeDefaults() {
+        assertEquals("app-status-pending", ApplicationStatusView.badgeClassFor(null));
+        assertEquals("Application status is currently unavailable.", ApplicationStatusView.summaryFor(null));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive features for applicant profile management, CV handling, and job application workflows for both applicants and organisers.

## Changes

### Profile Management
- Add profile completeness check methods (`hasCompleteProfile`, `isProfileComplete`)
- Add text parsing and formatting methods for skills and availability
- Support comma/newline separated text input for skills and working days

### CV Service
- Add `replaceCV` method to replace existing CV and clean up old files
- Add `hasUploadedCv` and `currentCvFileName` methods for status checking
- Validate user profile exists before CV upload
- Reject empty CV files
- Delete stale CV files when replacing

### Application Service
- Add `ApplicationService` with submit, query, and validation logic
- Add `ApplicationDetailServlet` for viewing application details
- Add `MyApplicationsServlet` for listing user's applications
- Add `reviewedAt` timestamp to track when applications are reviewed
- Add methods for organisers to view, open, and update application status
- Add sorted application listing for organisers

### Job Form Improvements
- Refactor `CreateJobServlet` to use shared job form template
- Preserve form data on validation errors
- Add `ApplicationStatusView` utility for display formatting

### Unit Tests
- Add comprehensive unit tests for `ApplicantService`
- Add unit tests for `CvService`
- Add unit tests for `ApplicationStatusView`

## Test plan
- [ ] Run all unit tests: `mvn test`
- [ ] Verify applicant profile creation with skills and working days
- [ ] Verify CV upload and replacement functionality
- [ ] Verify job application submission workflow
- [ ] Verify organiser can view and manage applications

Co-authored-by: mymyMai <144467412+mymymai@users.noreply.github.com>