### PR TITLE
feat: send messages on all application status changes (accept/reject/…

### DIFF
--- a/src/main/java/com/bupt/tarecruit/model/MessageType.java
+++ b/src/main/java/com/bupt/tarecruit/model/MessageType.java
@@ -1,6 +1,8 @@
 package com.bupt.tarecruit.model;
 
 public enum MessageType {
+    APPLICATION_ACCEPTED,
+    APPLICATION_REJECTED,
     APPLICATION_WITHDRAWN,
     JOB_CANCELLED
 }

--- a/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
+++ b/src/main/java/com/bupt/tarecruit/service/ApplicationService.java
@@ -192,6 +192,7 @@ public class ApplicationService {
             application.setReviewedAt(Instant.now());
         }
         applicationDao.save(application);
+        sendStatusChangeMessage(organiserUserId, application, status);
         if (status == ApplicationStatus.ACCEPTED) {
             rejectRemainingActiveApplicationsIfJobFilled(application);
         }
@@ -221,9 +222,7 @@ public class ApplicationService {
         ApplicationStatus previousStatus = application.getStatus();
         application.setStatus(ApplicationStatus.WITHDRAWN);
         applicationDao.save(application);
-        if (previousStatus == ApplicationStatus.ACCEPTED) {
-            sendAcceptedWithdrawalMessage(application);
-        }
+        sendWithdrawalMessage(application, previousStatus);
         return application;
     }
 
@@ -252,6 +251,8 @@ public class ApplicationService {
         if (!recruitmentPolicyService.isJobFull(acceptedApplication.getJobId())) {
             return;
         }
+        Job job = jobService.findById(acceptedApplication.getJobId())
+                .orElseThrow(() -> new IllegalArgumentException("The selected job does not exist."));
         Instant rejectionTime = Instant.now();
         applicationDao.findByJobId(acceptedApplication.getJobId()).stream()
                 .filter(application -> !acceptedApplication.getId().equals(application.getId()))
@@ -263,6 +264,14 @@ public class ApplicationService {
                         application.setReviewedAt(rejectionTime);
                     }
                     applicationDao.save(application);
+                    messageService.sendMessage(
+                            job.getOrganiserUserId(),
+                            application.getApplicantUserId(),
+                            "Application Rejected",
+                            "Your application for " + job.getTitle() + " has been rejected as the position is now filled.",
+                            MessageType.APPLICATION_REJECTED,
+                            application.getId(),
+                            job.getId());
                 });
     }
 
@@ -283,14 +292,46 @@ public class ApplicationService {
                 || status == ApplicationStatus.ACCEPTED;
     }
 
-    private void sendAcceptedWithdrawalMessage(final Application application) {
+    private void sendStatusChangeMessage(final String organiserUserId, final Application application,
+            final ApplicationStatus status) {
         Job job = jobService.findById(application.getJobId())
                 .orElseThrow(() -> new IllegalArgumentException("The selected job does not exist."));
+        String subject;
+        String content;
+        MessageType type;
+        if (status == ApplicationStatus.ACCEPTED) {
+            subject = "Application Accepted";
+            content = "Your application for " + job.getTitle() + " has been accepted.";
+            type = MessageType.APPLICATION_ACCEPTED;
+        } else {
+            subject = "Application Rejected";
+            content = "Your application for " + job.getTitle() + " has been rejected.";
+            type = MessageType.APPLICATION_REJECTED;
+        }
+        messageService.sendMessage(
+                organiserUserId,
+                application.getApplicantUserId(),
+                subject,
+                content,
+                type,
+                application.getId(),
+                job.getId());
+    }
+
+    private void sendWithdrawalMessage(final Application application, final ApplicationStatus previousStatus) {
+        Job job = jobService.findById(application.getJobId())
+                .orElseThrow(() -> new IllegalArgumentException("The selected job does not exist."));
+        String content;
+        if (previousStatus == ApplicationStatus.ACCEPTED) {
+            content = "An accepted application was withdrawn for " + job.getTitle() + ".";
+        } else {
+            content = "An application was withdrawn for " + job.getTitle() + ".";
+        }
         messageService.sendMessage(
                 application.getApplicantUserId(),
                 job.getOrganiserUserId(),
                 "Application Withdrawn",
-                "An accepted application was withdrawn for " + job.getTitle() + ".",
+                content,
                 MessageType.APPLICATION_WITHDRAWN,
                 application.getId(),
                 job.getId());

--- a/src/test/java/com/bupt/tarecruit/service/ApplicationServiceTest.java
+++ b/src/test/java/com/bupt/tarecruit/service/ApplicationServiceTest.java
@@ -540,7 +540,7 @@ class ApplicationServiceTest {
     }
 
     @Test
-    void pendingAndReviewingWithdrawalsDoNotNotifyOrganiser() throws Exception {
+    void pendingAndReviewingWithdrawalsNotifyOrganiser() throws Exception {
         TestContext context = createContext();
         Job pendingJob = createOpenJob(context.jobService, "organiser-1");
         Job reviewingJob = createOpenJob(context.jobService, "organiser-1");
@@ -554,7 +554,9 @@ class ApplicationServiceTest {
         context.applicationService.withdrawApplicationByApplicant("user-1", pending.getId());
         context.applicationService.withdrawApplicationByApplicant("user-1", reviewing.getId());
 
-        assertTrue(context.messageService.getMessagesForRecipient("organiser-1").isEmpty());
+        List<Message> organiserMessages = context.messageService.getMessagesForRecipient("organiser-1");
+        assertEquals(2, organiserMessages.size());
+        assertTrue(organiserMessages.stream().allMatch(m -> m.getType() == MessageType.APPLICATION_WITHDRAWN));
     }
 
     @Test


### PR DESCRIPTION
…withdraw)

Previously messages were only sent for accepted-application withdrawals and job cancellations. Now every status transition notifies the relevant party:
- Accept/Reject → message sent to applicant
- Withdraw (any prior status) → message sent to organiser
- Auto-reject when job fills → message sent to each affected applicant